### PR TITLE
Fixed input height to fill parent container

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -8,6 +8,10 @@
   --background-end-rgb: 255, 255, 255;
 }
 
+.tiptap { 
+	@apply p-6 flex-grow;
+}
+
 @media (prefers-color-scheme: dark) {
   :root {
     --foreground-rgb: 255, 255, 255;

--- a/src/components/editor/MarkdownEditor.tsx
+++ b/src/components/editor/MarkdownEditor.tsx
@@ -47,7 +47,7 @@ function MarkdownEditor({ initialContent, onSave, iconsSize = 18 }: MarkdownEdit
 
     return (
         <div className="w-full h-full flex flex-col min-h-96 bg-background text-foreground text-opacity-60">
-            <div data-cy="editor-menu" className="overflow-x-scroll w-full min-h-12 px-2 py-1 top-0 flex items-center border-b-border border-b gap-3 z-10 bg-background">
+            <div data-cy="editor-menu" className="overflow-x-scroll w-full min-h-12 px-2 py-1 top-0 sticky flex items-center border-b-border border-b gap-3 z-10 bg-background">
                 <NodeSelector editor={{
                     isActive: (node, attrs) => editor.isActive(node, attrs),
                     setNode: (node, attrs) => editor.chain().focus().setNode(node, attrs).run(),

--- a/src/components/editor/MarkdownEditor.tsx
+++ b/src/components/editor/MarkdownEditor.tsx
@@ -148,13 +148,11 @@ function MarkdownEditor({ initialContent, onSave, iconsSize = 18 }: MarkdownEdit
                     <SaveIcon size={iconsSize}/>
                 </Button>
             </div>
-            <div className="flex-grow overflow-y-auto relative">
-                <EditorContent 
-                    spellCheck={false} 
-                    className="h-full min-h-[400px] p-6 focus-within:outline-none focus-within:ring-2 focus-within:ring-ring focus-within:ring-offset-2" 
-                    editor={editor} 
-                />
-            </div>
+			<EditorContent 
+				spellCheck={false} 
+				className="flex content-stretch items-stretch flex-grow focus-within:outline-none focus-within:ring-2 focus-within:ring-ring focus-within:ring-offset-2" 
+				editor={editor} 
+			/>
         </div>
     );
 }


### PR DESCRIPTION
As you told me, for some reason the input area wasn't expanding to fill it's parent container. I think this was due to the way the browser deals with element heights, which can give headaches sometimes. In this case, since the container was a flex-item and had it's height derived from that, making it dynamic rather than fixed, applying `h-full` to it's children wouldn't work.

Anyways, configuring the container to also be a flex container worked, and the problem seems to be solved. However, this messed up the scrolling behaviour i had intended, and i had to apply `sticky` to the menu as a workaround. So it should be noted that the editor height will grow along the input. But you can easily limit that by wrapping the editor component with a container whose height will be fixed and has `overflow-y` configured to `scroll`.